### PR TITLE
Fix error message for missing `BLAS_LIBRARY` build option

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -665,7 +665,7 @@ FOREACH(ADDITIONAL_BLAS ${EXTRA})
     IF (${ADDITIONAL_BLAS}_LIBRARY)
         BuildBackendBlas(${ADDITIONAL_BLAS} backends/generic/backend.c)
     ELSE()
-        MESSAGE(FATAL_ERROR "-- ${ADDITIONAL_BLAS}_LIRBRAY missing.")
+        MESSAGE(FATAL_ERROR "-- ${ADDITIONAL_BLAS}_LIBRARY missing.")
     ENDIF()
 ENDFOREACH()
 


### PR DESCRIPTION
A very minor thing, but may as well get it fixed since the name is meaningful (I thought I had misspelled it after seeing the error).