### PR TITLE
issue #70 add support for ARMPL

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,4 +11,4 @@ Please list yourself, optionally with an affiliation, and a one-liner of your co
 * Christian Himpe, Universität Münster, testing and bug hunting
 * Jörn Papenbroock, parts of the hook framework 
 * Iñaki Úcar, packaging for Fedora and bug hunting related to the build-system
-
+* Julian Hornich, Siemens, adding support for ARMPL

--- a/src/flexiblas_api.h.in
+++ b/src/flexiblas_api.h.in
@@ -71,6 +71,8 @@ extern "C" {
 	extern void blas_set_num_threads(int num);
 	extern void acmlsetnumthreads(int num);
 	extern void bli_thread_set_num_threads(FLEXIBLAS_API_INT num);
+	extern void armpl_set_num_threads(int num);
+	extern void armpl_omp_set_num_threads(int num);
 
 	/* Get number of threads  */
 	extern int flexiblas_get_num_threads(void);
@@ -79,6 +81,8 @@ extern "C" {
 	extern int blas_get_num_threads(void);
 	extern int acmlgetnumthreads(void);
 	extern FLEXIBLAS_API_INT bli_thread_get_num_threads(void);
+	extern int armpl_get_num_threads(void);
+	extern int armpl_omp_get_num_threads(void);
 
 
 	/* Fortran Callable Routines, not intended to be called from C
@@ -93,14 +97,17 @@ extern "C" {
 	extern FLEXIBLAS_API_INT mkl_get_num_threads_(void);
 	extern FLEXIBLAS_API_INT flexiblas_get_num_threads_(void);
 	extern FLEXIBLAS_API_INT blas_get_num_threads_(void);
+	extern FLEXIBLAS_API_INT armpl_get_num_threads_(void);
+	extern FLEXIBLAS_API_INT armpl_omp_get_num_threads_(void);
 	extern void blas_set_num_threads_(FLEXIBLAS_API_INT* num);
 	extern void openblas_set_num_threads_(FLEXIBLAS_API_INT* num);
 	extern void mkl_set_num_threads_(FLEXIBLAS_API_INT* num);
 	extern void acmlsetnumthreads_(FLEXIBLAS_API_INT* num);
+	extern void armpl_set_num_threads_(FLEXIBLAS_API_INT* num);
+	extern void armpl_omp_set_num_threads_(FLEXIBLAS_API_INT* num);
 
 #ifdef __cplusplus
 };
 #endif
 
 #endif /* end of include guard: FLEXIBLAS_API_H */
-

--- a/src/flexiblas_api_standalone.c
+++ b/src/flexiblas_api_standalone.c
@@ -460,6 +460,26 @@ void bli_thread_set_num_threads(FLEXIBLAS_API_INT num)
     flexiblas_set_num_threads(num);
 }
 
+void armpl_set_num_threads(int num)
+{
+    flexiblas_set_num_threads(num);
+}
+
+void armpl_omp_set_num_threads(int num)
+{
+    flexiblas_set_num_threads(num);
+}
+
+void armpl_set_num_threads_(FLEXIBLAS_API_INT* num)
+{
+    flexiblas_set_num_threads(*num);
+}
+
+void armpl_omp_set_num_threads_(FLEXIBLAS_API_INT* num)
+{
+    flexiblas_set_num_threads(*num);
+}
+
 
 /* Get number of threads  */
 typedef int (*get_num_threads_t) (void);
@@ -540,5 +560,24 @@ FLEXIBLAS_API_INT bli_thread_get_num_threads(void)
     return (FLEXIBLAS_API_INT) flexiblas_get_num_threads();
 }
 
+int armpl_get_num_threads(void)
+{
+    return flexiblas_get_num_threads();
+}
+
+int armpl_omp_get_num_threads(void)
+{
+    return flexiblas_get_num_threads();
+}
+
+FLEXIBLAS_API_INT armpl_get_num_threads_(void)
+{
+    return (FLEXIBLAS_API_INT) flexiblas_get_num_threads();
+}
+
+FLEXIBLAS_API_INT armpl_omp_get_num_threads_(void)
+{
+    return (FLEXIBLAS_API_INT) flexiblas_get_num_threads();
+}
 
 

--- a/src/set_num_threads.c
+++ b/src/set_num_threads.c
@@ -45,7 +45,6 @@ void flexiblas_set_num_threads(int num)
         flexiblas_set_num_threads_(&nx);
         return;
     }
-    printf("BLAS\n");
     fn = current_backend->set_num_threads_function[0];
     if ( fn == NULL) return;
     fn (num);
@@ -59,7 +58,8 @@ void acmlsetnumthreads(int num) __attribute__((weak,alias("flexiblas_set_num_thr
 void blas_set_num_threads(int num) __attribute__((weak,alias("flexiblas_set_num_threads")));
 void nvpl_blas_set_num_threads(int num) __attribute__((weak,alias("flexiblas_set_num_threads")));
 void nvpl_lapack_set_num_threads(int num) __attribute__((weak,alias("flexiblas_set_num_threads")));
-
+void armpl_set_num_threads(int num) __attribute__((weak,alias("flexiblas_set_num_threads")));
+void armpl_omp_set_num_threads(int num) __attribute__((weak,alias("flexiblas_set_num_threads")));
 #else
 void openblas_set_num_threads(int num) { flexiblas_set_num_threads(num); }
 void mkl_set_num_threads(int num) { flexiblas_set_num_threads(num); }
@@ -67,7 +67,8 @@ void acmlsetnumthreads(int num) { flexiblas_set_num_threads(num); }
 void blas_set_num_threads(int num)  { flexiblas_set_num_threads(num); }
 void nvpl_blas_set_num_threads(int num)  { flexiblas_set_num_threads(num); }
 void nvpl_lapack_set_num_threads(int num)  { flexiblas_set_num_threads(num); }
-
+void armpl_set_num_threads(int num) { flexiblas_set_num_threads(num); }
+void armpl_omp_set_num_threads(int num) { flexiblas_set_num_threads(num); }
 #endif
 /* BLIS Interface */
 void bli_thread_set_num_threads(Int num) {
@@ -101,8 +102,8 @@ int  acmlgetnumthreads(void) __attribute__((weak,alias("flexiblas_get_num_thread
 int  blas_get_num_threads(void) __attribute__((weak,alias("flexiblas_get_num_threads")));
 int  nvpl_blas_get_max_threads(void) __attribute__((weak,alias("flexiblas_get_num_threads")));
 int  nvpl_lapack_get_max_threads(void) __attribute__((weak,alias("flexiblas_get_num_threads")));
-
-
+int  armpl_get_num_threads(void) __attribute__((weak,alias("flexiblas_get_num_threads")));
+int  armpl_omp_get_num_threads(void) __attribute__((weak,alias("flexiblas_get_num_threads")));
 #else
 int  openblas_get_num_threads(void) { return flexiblas_get_num_threads(); }
 int  mkl_get_num_threads(void)	{ return flexiblas_get_num_threads(); }
@@ -110,7 +111,8 @@ int  acmlgetnumthreads(void) 	{ return flexiblas_get_num_threads(); }
 int  blas_get_num_threads(void) 	{ return flexiblas_get_num_threads(); }
 int  nvpl_blas_get_max_threads(void) 	{ return flexiblas_get_num_threads(); }
 int  nvpl_lapack_get_max_threads(void) 	{ return flexiblas_get_num_threads(); }
-
+int  armpl_get_num_threads(void) { return flexiblas_get_num_threads(); }
+int  armpl_omp_get_num_threads(void) { return flexiblas_get_num_threads(); }
 #endif
 
 /*  BLIS Interface  */
@@ -150,12 +152,15 @@ void openblas_set_num_threads_(Int *num) __attribute__((weak, alias("flexiblas_s
 void mkl_set_num_threads_(Int *num) __attribute__((weak,alias("flexiblas_set_num_threads_")));
 void acmlsetnumthreads_(Int *num) __attribute__((weak,alias("flexiblas_set_num_threads_")));
 void blas_set_num_threads_(Int *num) __attribute__((weak,alias("flexiblas_set_num_threads_")));
+void armpl_set_num_threads_(Int *num) __attribute__((weak,alias("flexiblas_set_num_threads_")));
+void armpl_omp_set_num_threads_(Int *num) __attribute__((weak,alias("flexiblas_set_num_threads_")));
 #else
 void openblas_set_num_threads_(Int *num) { flexiblas_set_num_threads_(num); }
 void mkl_set_num_threads_(Int *num)      { flexiblas_set_num_threads_(num); }
 void acmlsetnumthreads_(Int *num)        { flexiblas_set_num_threads_(num); }
 void blas_set_num_threads_(Int *num)     { flexiblas_set_num_threads_(num); }
-
+void armpl_set_num_threads_(Int *num)    { flexiblas_set_num_threads_(num); }
+void armpl_omp_set_num_threads_(Int *num) { flexiblas_set_num_threads_(num); }
 #endif
 
 void nvpl_blas_set_num_threads_(int32_t* num)
@@ -195,12 +200,15 @@ Int  openblas_get_num_threads_(void) __attribute__((weak, alias("flexiblas_get_n
 Int  mkl_get_num_threads_(void) __attribute__((weak,alias("flexiblas_get_num_threads_")));
 Int  acmlgetnumthreads_(void) __attribute__((weak,alias("flexiblas_get_num_threads_")));
 Int  blas_get_num_threads_(void) __attribute__((weak,alias("flexiblas_get_num_threads_")));
+Int  armpl_get_num_threads_(void) __attribute__((weak,alias("flexiblas_get_num_threads_")));
+Int  armpl_omp_get_num_threads_(void) __attribute__((weak,alias("flexiblas_get_num_threads_")));
 #else
 Int  openblas_get_num_threads_(void) { return flexiblas_get_num_threads_(); }
 Int  mkl_get_num_threads_(void)      { return flexiblas_get_num_threads_(); }
 Int  acmlgetnumthreads_(void)        { return flexiblas_get_num_threads_(); }
 Int  blas_get_num_threads_(void)     { return flexiblas_get_num_threads_(); }
-
+Int  armpl_get_num_threads_(void)    { return flexiblas_get_num_threads_(); }
+Int  armpl_omp_get_num_threads_(void) { return flexiblas_get_num_threads_(); }
 #endif
 
 int32_t  nvpl_blas_get_max_threads_(void) 	{ return (int32_t) flexiblas_get_num_threads_(); }
@@ -217,7 +225,7 @@ void __flexiblas_load_set_num_threads(flexiblas_backend_t * backend)
     char fn2_name[130];
     int i = 0;
 
-    for (i = 0; i < 6; i++) {
+    for (i = 0; i < 8; i++) {
         if (i == 0 )
             strncpy(fn_name, "hook_set_num_threads",127);
         else if ( i == 1) {
@@ -231,7 +239,11 @@ void __flexiblas_load_set_num_threads(flexiblas_backend_t * backend)
             strncpy(fn_name, "bli_thread_set_num_threads", 127);
         else if ( i == 5 )
             strncpy(fn_name, "flexiblas_backend_set_num_threads", 127);
-
+        else if ( i == 6 ) {
+            strncpy(fn_name, "armpl_omp_set_num_threads", 127);
+        } else if ( i == 7 ) {
+            strncpy(fn_name, "armpl_set_num_threads", 127);
+        }
         fn_name[127] = '\0';
         if ( i != 1 ) {
             snprintf(fn2_name, 130, "%s_", fn_name);
@@ -267,7 +279,7 @@ void __flexiblas_load_get_num_threads(flexiblas_backend_t * backend)
     char fn2_name[130];
     int i = 0;
 
-    for (i = 0; i < 6; i++) {
+    for (i = 0; i < 8; i++) {
         if (i == 0 )
             strncpy(fn_name, "hook_get_num_threads",127);
         else if ( i == 1) {
@@ -281,6 +293,11 @@ void __flexiblas_load_get_num_threads(flexiblas_backend_t * backend)
             strncpy(fn_name, "bli_thread_get_num_threads",127);
         else if ( i == 5 )
             strncpy(fn_name, "flexiblas_backend_ge_num_threads", 127);
+        else if ( i == 6 ) {
+            strncpy(fn_name, "armpl_omp_get_num_threads",127);
+        } else if ( i == 7 ) {
+            strncpy(fn_name, "armpl_get_num_threads",127);
+        }
 
         fn_name[127] = '\0';
         if ( i != 1 )
@@ -304,5 +321,4 @@ void __flexiblas_load_get_num_threads(flexiblas_backend_t * backend)
 
     return;
 }
-
 


### PR DESCRIPTION
This addes support for the the threading API of ARMPL.
There are two types of functions added, since ARM decided to change the function names ~2 releases ago and we probably want to have support for both. Depending on the used version there will only be on or the other function available.