### PR TITLE
CI: Add CI rules for GitHub-hosted Ubuntu runners

### DIFF
--- a/.github/workflows/build-ubuntu.yaml
+++ b/.github/workflows/build-ubuntu.yaml
@@ -33,11 +33,14 @@ jobs:
             compiler-pkgs: "g++ gcc"
             cc: "gcc"
             cxx: "g++"
-          - os: ubuntu-latest
-            compiler: clang
-            compiler-pkgs: "clang"
-            cc: "clang"
-            cxx: "clang++"
+          # Building with Clang fails with a linker error:
+          #   undefined reference to `csc_cycles'
+          # Comment out for now.
+          # - os: ubuntu-latest
+          #   compiler: clang
+          #   compiler-pkgs: "clang"
+          #   cc: "clang"
+          #   cxx: "clang++"
 
     env:
       CC: ${{ matrix.cc }}
@@ -78,7 +81,7 @@ jobs:
       - name: configure ccache
         run: |
           test -d ~/.ccache || mkdir ~/.ccache
-          echo "max_size = 600M" >> ~/.ccache/ccache.conf
+          echo "max_size = 400M" >> ~/.ccache/ccache.conf
           echo "compression = true" >> ~/.ccache/ccache.conf
           ccache -s
           echo "/usr/lib/ccache" >> $GITHUB_PATH

--- a/.github/workflows/build-ubuntu.yaml
+++ b/.github/workflows/build-ubuntu.yaml
@@ -1,0 +1,138 @@
+name: build
+on:
+  workflow_dispatch:
+  push:
+  pull_request:
+
+concurrency: ci-ubuntu-${{ github.ref }}
+
+jobs:
+
+  ubuntu:
+    # For available GitHub-hosted runners, see:
+    # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
+    runs-on: ${{ matrix.os }}
+
+    name: ${{ matrix.os }} (${{ matrix.compiler }})
+
+    strategy:
+      # Allow other runners in the matrix to continue if some fail
+      fail-fast: false
+
+      matrix:
+        os: [ubuntu-latest]
+        compiler: [gcc]
+        include:
+          - os: ubuntu-latest
+            compiler: gcc
+            compiler-pkgs: "g++ gcc"
+            cc: "gcc"
+            cxx: "g++"
+          - os: ubuntu-24.04-arm
+            compiler: gcc
+            compiler-pkgs: "g++ gcc"
+            cc: "gcc"
+            cxx: "g++"
+          - os: ubuntu-latest
+            compiler: clang
+            compiler-pkgs: "clang"
+            cc: "clang"
+            cxx: "clang++"
+
+    env:
+      CC: ${{ matrix.cc }}
+      CXX: ${{ matrix.cxx }}
+
+    steps:
+      - name: get CPU information
+        run: lscpu
+
+      - name: checkout repository
+        uses: actions/checkout@v4
+
+      - name: install dependencies
+        run: |
+          sudo apt -qq update
+          sudo apt install -y ${{ matrix.compiler-pkgs }} gfortran cmake ccache \
+            ${{ matrix.compiler == 'clang' && 'libomp-dev' || '' }} \
+            libblas-dev liblapack-dev libopenblas-dev
+
+      - name: prepare ccache
+        # create key with human readable timestamp
+        # used in action/cache/restore and action/cache/save steps
+        id: ccache-prepare
+        run: |
+          echo "key=ccache:${{ matrix.os }}:${{ matrix.compiler }}::${{ github.ref }}:$(date +"%Y-%m-%d_%H-%M-%S"):${{ github.sha }}" >> $GITHUB_OUTPUT
+
+      - name: restore ccache
+        # setup the GitHub cache used to maintain the ccache from one job to the next
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.ccache
+          key: ${{ steps.ccache-prepare.outputs.key }}
+          # Prefer caches from the same branch. Fall back to caches from the dev branch.
+          restore-keys: |
+            ccache:${{ matrix.os }}:${{ matrix.compiler }}:${{ github.ref }}:
+            ccache:${{ matrix.os }}:${{ matrix.compiler }}:
+
+      - name: configure ccache
+        run: |
+          test -d ~/.ccache || mkdir ~/.ccache
+          echo "max_size = 600M" >> ~/.ccache/ccache.conf
+          echo "compression = true" >> ~/.ccache/ccache.conf
+          ccache -s
+          echo "/usr/lib/ccache" >> $GITHUB_PATH
+
+      - name: configure
+        run: |
+          mkdir ${GITHUB_WORKSPACE}/build
+          cd ${GITHUB_WORKSPACE}/build
+          cmake \
+            -DCMAKE_BUILD_TYPE="Release" \
+            -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}/usr" \
+            ..
+
+      - name: build
+        run: |
+          cd ${GITHUB_WORKSPACE}/build
+          cmake --build . -j$(nproc)
+
+      - name: ccache status
+        continue-on-error: true
+        run: ccache -s
+
+      - name: save ccache
+        # Save the cache after we are done (successfully) building
+        # This helps to retain the ccache even if the subsequent steps are failing.
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.ccache
+          key: ${{ steps.ccache-prepare.outputs.key }}
+
+      - name: install
+        run: |
+          cd ${GITHUB_WORKSPACE}/build
+          cmake --install .
+
+      - name: check
+        id: run-ctest
+        timeout-minutes: 150
+        run: |
+          cd ${GITHUB_WORKSPACE}/build
+          ctest . \
+            -j$(nproc) \
+            --timeout 300
+
+      - name: Re-run tests
+        if: always() && (steps.run-ctest.outcome == 'failure')
+        timeout-minutes: 60
+        env:
+          CTEST_OUTPUT_ON_FAILURE: 1
+        run: |
+          cd ${GITHUB_WORKSPACE}/build
+          echo "::group::Re-run failing tests"
+          ctest --rerun-failed --output-on-failure --timeout 180 || true
+          echo "::endgroup::"
+          echo "::group::Log from these tests"
+          [ ! -f Testing/Temporary/LastTest.log ] || cat Testing/Temporary/LastTest.log
+          echo "::endgroup::"


### PR DESCRIPTION
While looking into potentially porting FlexiBLAS to Windows (MSVC or MinGW), it might be nice to have some checks that nothing breaks on other platforms on the way.

Are you interested in setting up some CI rules for this repository?
In case you are, this PR uses GitHub-hosted Ubuntu runners to add these tests.

At the moment, only the most basic build configuration is tested. But it shouldn't be too hard to expand from there.

I also haven't looked into much detail of how the test suite works. Would it need to be re-run for different BLAS/LAPACK backends?

I tried to add a runner to the build matrix that uses Clang as the compiler. However, it failed linking an example with an `undefined reference to 'csc_cycles'` error. I haven't looked into why that is failing.
I left the CI rules that I had at that point in and only commented out the respective part of the CI matrix. I hope that is ok.

If I recall correctly, the CI rules must be merged to the default branch of the repository before the CI actually triggers. You might also need to enable running actions by clicking on a button on the "Actions" tab after (or if) this PR is merged.
Currently, there is a manual trigger that maintainers of this repository can use to trigger a CI run at any time. Additionally, there are automatic triggers to run the CI for pull request and whenever a change is pushed to the repository.
Is that ok?
