### PR TITLE
Greatly expand Ubuntu CI

### DIFF
--- a/.github/workflows/build-ubuntu.yaml
+++ b/.github/workflows/build-ubuntu.yaml
@@ -71,7 +71,7 @@ jobs:
         # used in action/cache/restore and action/cache/save steps
         id: ccache-prepare
         run: |
-          echo "key=ccache:${{ matrix.os }}:${{ matrix.compiler }}::${{ github.ref }}:$(date +"%Y-%m-%d_%H-%M-%S"):${{ github.sha }}" >> $GITHUB_OUTPUT
+          echo "key=ccache:${{ matrix.os }}:${{ matrix.compiler }}:${{ github.ref }}:$(date +"%Y-%m-%d_%H-%M-%S"):${{ github.sha }}" >> $GITHUB_OUTPUT
 
       - name: restore ccache
         # setup the GitHub cache used to maintain the ccache from one job to the next

--- a/.github/workflows/build-ubuntu.yaml
+++ b/.github/workflows/build-ubuntu.yaml
@@ -173,7 +173,7 @@ jobs:
           cd ${GITHUB_WORKSPACE}/build
           ${{ matrix.integer8 && 'I8SUFFIX=64' || '' }}
           cmake \
-            -DCMAKE_BUILD_TYPE="Release" \
+            -DCMAKE_BUILD_TYPE="Debug" \
             -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}/usr" \
             ${{ matrix.link-blas && '-DSYS_BLAS_LIBRARY=$(dpkg -L libblas$I8SUFFIX-dev | grep "libblas$I8SUFFIX.so\$")' || '' }} \
             ${{ matrix.link-cblas && '-DSYS_CBLAS_LIBRARY=$(dpkg -L libblas$I8SUFFIX-dev | grep "libblas$I8SUFFIX.so\$")' || '' }} \

--- a/.github/workflows/build-ubuntu.yaml
+++ b/.github/workflows/build-ubuntu.yaml
@@ -13,21 +13,27 @@ jobs:
     # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
     runs-on: ${{ matrix.os }}
 
-    name: ${{ matrix.os }} (${{ matrix.compiler }})
+    name: >-
+      ${{ matrix.os }} (${{ matrix.compiler }})
+      ${{ matrix.link-blas && ' link-blas' || '' }}
 
     strategy:
       # Allow other runners in the matrix to continue if some fail
       fail-fast: false
 
       matrix:
-        os: [ubuntu-latest]
-        compiler: [gcc]
         include:
           - os: ubuntu-latest
             compiler: gcc
             compiler-pkgs: "g++ gcc"
             cc: "gcc"
             cxx: "g++"
+          - os: ubuntu-latest
+            compiler: gcc
+            compiler-pkgs: "g++ gcc"
+            cc: "gcc"
+            cxx: "g++"
+            link-blas: true
           - os: ubuntu-24.04-arm
             compiler: gcc
             compiler-pkgs: "g++ gcc"
@@ -58,7 +64,7 @@ jobs:
           sudo apt -qq update
           sudo apt install -y ${{ matrix.compiler-pkgs }} gfortran cmake ccache \
             ${{ matrix.compiler == 'clang' && 'libomp-dev' || '' }} \
-            libblas-dev liblapack-dev libopenblas-dev
+            libblas-dev liblapack-dev liblapacke-dev libopenblas-dev
 
       - name: prepare ccache
         # create key with human readable timestamp
@@ -93,6 +99,7 @@ jobs:
           cmake \
             -DCMAKE_BUILD_TYPE="Release" \
             -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}/usr" \
+            ${{ matrix.link-blas && '-DSYS_BLAS_LIBRARY=$(dpkg -L libblas-dev | grep "libblas.so\$")' || '' }} \
             ..
 
       - name: build

--- a/.github/workflows/build-ubuntu.yaml
+++ b/.github/workflows/build-ubuntu.yaml
@@ -139,7 +139,8 @@ jobs:
           ${{ matrix.integer8 && 'I8SUFFIX=64' || '' }}
           sudo apt install -y ${{ matrix.compiler-pkgs }} gfortran cmake ccache \
             ${{ matrix.compiler == 'clang' && 'libomp-dev' || '' }} \
-            libblas$I8SUFFIX-dev liblapack$I8SUFFIX-dev liblapacke$I8SUFFIX-dev libopenblas$I8SUFFIX-dev
+            libopenblas$I8SUFFIX-dev \
+            libblas$I8SUFFIX-dev liblapack$I8SUFFIX-dev liblapacke$I8SUFFIX-dev
 
       - name: prepare ccache
         # create key with human readable timestamp
@@ -178,6 +179,7 @@ jobs:
             ${{ matrix.link-blas && '-DSYS_BLAS_LIBRARY=$(dpkg -L libblas$I8SUFFIX-dev | grep "libblas$I8SUFFIX.so\$")' || '' }} \
             ${{ matrix.link-cblas && '-DSYS_CBLAS_LIBRARY=$(dpkg -L libblas$I8SUFFIX-dev | grep "libblas$I8SUFFIX.so\$")' || '' }} \
             ${{ matrix.link-lapack && '-DSYS_LAPACK_LIBRARY=$(dpkg -L liblapack$I8SUFFIX-dev | grep "liblapack$I8SUFFIX.so\$")' || '' }} \
+            ${{ matrix.link-lapack && '-DLAPACK_API_VERSION=$(dpkg -s liblapack$I8SUFFIX-dev | perl -nE "say \$1 if /^Version: ([0-9.]+)/")' || '' }} \
             ${{ matrix.link-lapacke && '-DSYS_LAPACKE_LIBRARY=$(dpkg -L liblapacke$I8SUFFIX-dev | grep "liblapacke$I8SUFFIX.so\$")' || '' }} \
             ${{ matrix.integer8 && '-DINTEGER8=ON' || '' }} \
             ..

--- a/.github/workflows/build-ubuntu.yaml
+++ b/.github/workflows/build-ubuntu.yaml
@@ -51,7 +51,7 @@ jobs:
         run: lscpu
 
       - name: checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: install dependencies
         run: |
@@ -69,7 +69,7 @@ jobs:
 
       - name: restore ccache
         # setup the GitHub cache used to maintain the ccache from one job to the next
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: ~/.ccache
           key: ${{ steps.ccache-prepare.outputs.key }}
@@ -107,7 +107,7 @@ jobs:
       - name: save ccache
         # Save the cache after we are done (successfully) building
         # This helps to retain the ccache even if the subsequent steps are failing.
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v6
         with:
           path: ~/.ccache
           key: ${{ steps.ccache-prepare.outputs.key }}

--- a/.github/workflows/build-ubuntu.yaml
+++ b/.github/workflows/build-ubuntu.yaml
@@ -18,6 +18,7 @@ jobs:
       ${{ matrix.link-blas && ' link-blas' || '' }}
       ${{ matrix.link-cblas && ' link-cblas' || '' }}
       ${{ matrix.link-lapack && ' link-lapack' || '' }}
+      ${{ matrix.link-lapacke && ' link-lapacke' || '' }}
 
     strategy:
       # Allow other runners in the matrix to continue if some fail
@@ -51,6 +52,15 @@ jobs:
             link-blas: true
             link-cblas: true
             link-lapack: true
+          - os: ubuntu-latest
+            compiler: gcc
+            compiler-pkgs: "g++ gcc"
+            cc: "gcc"
+            cxx: "g++"
+            link-blas: true
+            link-cblas: true
+            link-lapack: true
+            link-lapacke: true
           - os: ubuntu-24.04-arm
             compiler: gcc
             compiler-pkgs: "g++ gcc"
@@ -119,6 +129,7 @@ jobs:
             ${{ matrix.link-blas && '-DSYS_BLAS_LIBRARY=$(dpkg -L libblas-dev | grep "libblas.so\$")' || '' }} \
             ${{ matrix.link-cblas && '-DSYS_CBLAS_LIBRARY=$(dpkg -L libblas-dev | grep "libblas.so\$")' || '' }} \
             ${{ matrix.link-lapack && '-DSYS_LAPACK_LIBRARY=$(dpkg -L liblapack-dev | grep "liblapack.so\$")' || '' }} \
+            ${{ matrix.link-lapacke && '-DSYS_LAPACKE_LIBRARY=$(dpkg -L liblapacke-dev | grep "liblapacke.so\$")' || '' }} \
             ..
 
       - name: build

--- a/.github/workflows/build-ubuntu.yaml
+++ b/.github/workflows/build-ubuntu.yaml
@@ -146,7 +146,7 @@ jobs:
         # used in action/cache/restore and action/cache/save steps
         id: ccache-prepare
         run: |
-          echo "key=ccache:${{ matrix.os }}:${{ matrix.compiler }}:${{ github.ref }}:$(date +"%Y-%m-%d_%H-%M-%S"):${{ github.sha }}" >> $GITHUB_OUTPUT
+          echo "key=ccache:${{ matrix.os }}:${{ matrix.compiler }}:${{ matrix.integer8 && '64' || '32' }}bit:${{ github.ref }}:$(date +"%Y-%m-%d_%H-%M-%S"):${{ github.sha }}" >> $GITHUB_OUTPUT
 
       - name: restore ccache
         # setup the GitHub cache used to maintain the ccache from one job to the next
@@ -156,8 +156,8 @@ jobs:
           key: ${{ steps.ccache-prepare.outputs.key }}
           # Prefer caches from the same branch. Fall back to caches from the dev branch.
           restore-keys: |
-            ccache:${{ matrix.os }}:${{ matrix.compiler }}:${{ github.ref }}:
-            ccache:${{ matrix.os }}:${{ matrix.compiler }}:
+            ccache:${{ matrix.os }}:${{ matrix.compiler }}:${{ matrix.integer8 && '64' || '32' }}bit:${{ github.ref }}:
+            ccache:${{ matrix.os }}:${{ matrix.compiler }}:${{ matrix.integer8 && '64' || '32' }}bit:
 
       - name: configure ccache
         run: |

--- a/.github/workflows/build-ubuntu.yaml
+++ b/.github/workflows/build-ubuntu.yaml
@@ -15,6 +15,7 @@ jobs:
 
     name: >-
       ${{ matrix.os }} (${{ matrix.compiler }})
+      ${{ matrix.integer8 && ' 64-bit' || '' }}
       ${{ matrix.link-blas && ' link-blas' || '' }}
       ${{ matrix.link-cblas && ' link-cblas' || '' }}
       ${{ matrix.link-lapack && ' link-lapack' || '' }}
@@ -61,11 +62,57 @@ jobs:
             link-cblas: true
             link-lapack: true
             link-lapacke: true
+          - os: ubuntu-latest
+            compiler: gcc
+            compiler-pkgs: "g++ gcc"
+            cc: "gcc"
+            cxx: "g++"
+            integer8: true
+          - os: ubuntu-latest
+            compiler: gcc
+            compiler-pkgs: "g++ gcc"
+            cc: "gcc"
+            cxx: "g++"
+            integer8: true
+            link-blas: true
+          - os: ubuntu-latest
+            compiler: gcc
+            compiler-pkgs: "g++ gcc"
+            cc: "gcc"
+            cxx: "g++"
+            integer8: true
+            link-blas: true
+            link-cblas: true
+          - os: ubuntu-latest
+            compiler: gcc
+            compiler-pkgs: "g++ gcc"
+            cc: "gcc"
+            cxx: "g++"
+            integer8: true
+            link-blas: true
+            link-cblas: true
+            link-lapack: true
+          - os: ubuntu-latest
+            compiler: gcc
+            compiler-pkgs: "g++ gcc"
+            cc: "gcc"
+            cxx: "g++"
+            integer8: true
+            link-blas: true
+            link-cblas: true
+            link-lapack: true
+            link-lapacke: true
           - os: ubuntu-24.04-arm
             compiler: gcc
             compiler-pkgs: "g++ gcc"
             cc: "gcc"
             cxx: "g++"
+          - os: ubuntu-24.04-arm
+            compiler: gcc
+            compiler-pkgs: "g++ gcc"
+            cc: "gcc"
+            cxx: "g++"
+            integer8: true
           # Building with Clang fails with a linker error:
           #   undefined reference to `csc_cycles'
           # Comment out for now.
@@ -89,9 +136,10 @@ jobs:
       - name: install dependencies
         run: |
           sudo apt -qq update
+          ${{ matrix.integer8 && 'I8SUFFIX=64' || '' }}
           sudo apt install -y ${{ matrix.compiler-pkgs }} gfortran cmake ccache \
             ${{ matrix.compiler == 'clang' && 'libomp-dev' || '' }} \
-            libblas-dev liblapack-dev liblapacke-dev libopenblas-dev
+            libblas$I8SUFFIX-dev liblapack$I8SUFFIX-dev liblapacke$I8SUFFIX-dev libopenblas$I8SUFFIX-dev
 
       - name: prepare ccache
         # create key with human readable timestamp
@@ -123,13 +171,15 @@ jobs:
         run: |
           mkdir ${GITHUB_WORKSPACE}/build
           cd ${GITHUB_WORKSPACE}/build
+          ${{ matrix.integer8 && 'I8SUFFIX=64' || '' }}
           cmake \
             -DCMAKE_BUILD_TYPE="Release" \
             -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}/usr" \
-            ${{ matrix.link-blas && '-DSYS_BLAS_LIBRARY=$(dpkg -L libblas-dev | grep "libblas.so\$")' || '' }} \
-            ${{ matrix.link-cblas && '-DSYS_CBLAS_LIBRARY=$(dpkg -L libblas-dev | grep "libblas.so\$")' || '' }} \
-            ${{ matrix.link-lapack && '-DSYS_LAPACK_LIBRARY=$(dpkg -L liblapack-dev | grep "liblapack.so\$")' || '' }} \
-            ${{ matrix.link-lapacke && '-DSYS_LAPACKE_LIBRARY=$(dpkg -L liblapacke-dev | grep "liblapacke.so\$")' || '' }} \
+            ${{ matrix.link-blas && '-DSYS_BLAS_LIBRARY=$(dpkg -L libblas$I8SUFFIX-dev | grep "libblas$I8SUFFIX.so\$")' || '' }} \
+            ${{ matrix.link-cblas && '-DSYS_CBLAS_LIBRARY=$(dpkg -L libblas$I8SUFFIX-dev | grep "libblas$I8SUFFIX.so\$")' || '' }} \
+            ${{ matrix.link-lapack && '-DSYS_LAPACK_LIBRARY=$(dpkg -L liblapack$I8SUFFIX-dev | grep "liblapack$I8SUFFIX.so\$")' || '' }} \
+            ${{ matrix.link-lapacke && '-DSYS_LAPACKE_LIBRARY=$(dpkg -L liblapacke$I8SUFFIX-dev | grep "liblapacke$I8SUFFIX.so\$")' || '' }} \
+            ${{ matrix.integer8 && '-DINTEGER8=ON' || '' }} \
             ..
 
       - name: build

--- a/.github/workflows/build-ubuntu.yaml
+++ b/.github/workflows/build-ubuntu.yaml
@@ -16,6 +16,7 @@ jobs:
     name: >-
       ${{ matrix.os }} (${{ matrix.compiler }})
       ${{ matrix.link-blas && ' link-blas' || '' }}
+      ${{ matrix.link-cblas && ' link-cblas' || '' }}
 
     strategy:
       # Allow other runners in the matrix to continue if some fail
@@ -34,6 +35,13 @@ jobs:
             cc: "gcc"
             cxx: "g++"
             link-blas: true
+          - os: ubuntu-latest
+            compiler: gcc
+            compiler-pkgs: "g++ gcc"
+            cc: "gcc"
+            cxx: "g++"
+            link-blas: true
+            link-cblas: true
           - os: ubuntu-24.04-arm
             compiler: gcc
             compiler-pkgs: "g++ gcc"
@@ -100,6 +108,7 @@ jobs:
             -DCMAKE_BUILD_TYPE="Release" \
             -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}/usr" \
             ${{ matrix.link-blas && '-DSYS_BLAS_LIBRARY=$(dpkg -L libblas-dev | grep "libblas.so\$")' || '' }} \
+            ${{ matrix.link-cblas && '-DSYS_CBLAS_LIBRARY=$(dpkg -L libblas-dev | grep "libblas.so\$")' || '' }} \
             ..
 
       - name: build

--- a/.github/workflows/build-ubuntu.yaml
+++ b/.github/workflows/build-ubuntu.yaml
@@ -17,6 +17,7 @@ jobs:
       ${{ matrix.os }} (${{ matrix.compiler }})
       ${{ matrix.link-blas && ' link-blas' || '' }}
       ${{ matrix.link-cblas && ' link-cblas' || '' }}
+      ${{ matrix.link-lapack && ' link-lapack' || '' }}
 
     strategy:
       # Allow other runners in the matrix to continue if some fail
@@ -42,6 +43,14 @@ jobs:
             cxx: "g++"
             link-blas: true
             link-cblas: true
+          - os: ubuntu-latest
+            compiler: gcc
+            compiler-pkgs: "g++ gcc"
+            cc: "gcc"
+            cxx: "g++"
+            link-blas: true
+            link-cblas: true
+            link-lapack: true
           - os: ubuntu-24.04-arm
             compiler: gcc
             compiler-pkgs: "g++ gcc"
@@ -109,6 +118,7 @@ jobs:
             -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}/usr" \
             ${{ matrix.link-blas && '-DSYS_BLAS_LIBRARY=$(dpkg -L libblas-dev | grep "libblas.so\$")' || '' }} \
             ${{ matrix.link-cblas && '-DSYS_CBLAS_LIBRARY=$(dpkg -L libblas-dev | grep "libblas.so\$")' || '' }} \
+            ${{ matrix.link-lapack && '-DSYS_LAPACK_LIBRARY=$(dpkg -L liblapack-dev | grep "liblapack.so\$")' || '' }} \
             ..
 
       - name: build

--- a/.github/workflows/build-ubuntu.yaml
+++ b/.github/workflows/build-ubuntu.yaml
@@ -1,4 +1,4 @@
-name: build
+name: build-ubuntu
 on:
   workflow_dispatch:
   push:

--- a/test/blas/cblas/runtest.cmake
+++ b/test/blas/cblas/runtest.cmake
@@ -1,5 +1,5 @@
 # Replace INTDIR with the value of $ENV{CMAKE_CONFIG_TYPE} that is set
-# by ctest when -C Debug|Releaes|etc is given, and INDIR is passed
+# by ctest when -C Debug|Release|etc is given, and INDIR is passed
 # in from the main cmake run and is the variable that is used
 # by the build system to specify the build directory
 if(NOT "${INTDIR}" STREQUAL ".")

--- a/test/blas/runtest.cmake
+++ b/test/blas/runtest.cmake
@@ -1,5 +1,5 @@
 # Replace INTDIR with the value of $ENV{CMAKE_CONFIG_TYPE} that is set
-# by ctest when -C Debug|Releaes|etc is given, and INDIR is passed
+# by ctest when -C Debug|Release|etc is given, and INDIR is passed
 # in from the main cmake run and is the variable that is used
 # by the build system to specify the build directory
 #if(NOT "${INTDIR}" STREQUAL ".")

--- a/test/lapack-3.10.0/runtest.cmake
+++ b/test/lapack-3.10.0/runtest.cmake
@@ -1,5 +1,5 @@
 # Replace INTDIR with the value of $ENV{CMAKE_CONFIG_TYPE} that is set
-# by ctest when -C Debug|Releaes|etc is given, and INDIR is passed
+# by ctest when -C Debug|Release|etc is given, and INDIR is passed
 # in from the main cmake run and is the variable that is used
 # by the build system to specify the build directory
 if(NOT "${INTDIR}" STREQUAL ".")

--- a/test/lapack-3.10.1/runtest.cmake
+++ b/test/lapack-3.10.1/runtest.cmake
@@ -1,5 +1,5 @@
 # Replace INTDIR with the value of $ENV{CMAKE_CONFIG_TYPE} that is set
-# by ctest when -C Debug|Releaes|etc is given, and INDIR is passed
+# by ctest when -C Debug|Release|etc is given, and INDIR is passed
 # in from the main cmake run and is the variable that is used
 # by the build system to specify the build directory
 if(NOT "${INTDIR}" STREQUAL ".")

--- a/test/lapack-3.11.0/runtest.cmake
+++ b/test/lapack-3.11.0/runtest.cmake
@@ -1,5 +1,5 @@
 # Replace INTDIR with the value of $ENV{CMAKE_CONFIG_TYPE} that is set
-# by ctest when -C Debug|Releaes|etc is given, and INDIR is passed
+# by ctest when -C Debug|Release|etc is given, and INDIR is passed
 # in from the main cmake run and is the variable that is used
 # by the build system to specify the build directory
 if(NOT "${INTDIR}" STREQUAL ".")

--- a/test/lapack-3.12.0/runtest.cmake
+++ b/test/lapack-3.12.0/runtest.cmake
@@ -1,5 +1,5 @@
 # Replace INTDIR with the value of $ENV{CMAKE_CONFIG_TYPE} that is set
-# by ctest when -C Debug|Releaes|etc is given, and INDIR is passed
+# by ctest when -C Debug|Release|etc is given, and INDIR is passed
 # in from the main cmake run and is the variable that is used
 # by the build system to specify the build directory
 if(NOT "${INTDIR}" STREQUAL ".")

--- a/test/lapack-3.12.1/runtest.cmake
+++ b/test/lapack-3.12.1/runtest.cmake
@@ -1,5 +1,5 @@
 # Replace INTDIR with the value of $ENV{CMAKE_CONFIG_TYPE} that is set
-# by ctest when -C Debug|Releaes|etc is given, and INDIR is passed
+# by ctest when -C Debug|Release|etc is given, and INDIR is passed
 # in from the main cmake run and is the variable that is used
 # by the build system to specify the build directory
 if(NOT "${INTDIR}" STREQUAL ".")

--- a/test/lapack-3.6.1/runtest.cmake
+++ b/test/lapack-3.6.1/runtest.cmake
@@ -1,5 +1,5 @@
 # Replace INTDIR with the value of $ENV{CMAKE_CONFIG_TYPE} that is set
-# by ctest when -C Debug|Releaes|etc is given, and INDIR is passed
+# by ctest when -C Debug|Release|etc is given, and INDIR is passed
 # in from the main cmake run and is the variable that is used
 # by the build system to specify the build directory
 if(NOT "${INTDIR}" STREQUAL ".")

--- a/test/lapack-3.7.0/runtest.cmake
+++ b/test/lapack-3.7.0/runtest.cmake
@@ -1,5 +1,5 @@
 # Replace INTDIR with the value of $ENV{CMAKE_CONFIG_TYPE} that is set
-# by ctest when -C Debug|Releaes|etc is given, and INDIR is passed
+# by ctest when -C Debug|Release|etc is given, and INDIR is passed
 # in from the main cmake run and is the variable that is used
 # by the build system to specify the build directory
 if(NOT "${INTDIR}" STREQUAL ".")

--- a/test/lapack-3.8.0/runtest.cmake
+++ b/test/lapack-3.8.0/runtest.cmake
@@ -1,5 +1,5 @@
 # Replace INTDIR with the value of $ENV{CMAKE_CONFIG_TYPE} that is set
-# by ctest when -C Debug|Releaes|etc is given, and INDIR is passed
+# by ctest when -C Debug|Release|etc is given, and INDIR is passed
 # in from the main cmake run and is the variable that is used
 # by the build system to specify the build directory
 if(NOT "${INTDIR}" STREQUAL ".")

--- a/test/lapack-3.9.0/runtest.cmake
+++ b/test/lapack-3.9.0/runtest.cmake
@@ -1,5 +1,5 @@
 # Replace INTDIR with the value of $ENV{CMAKE_CONFIG_TYPE} that is set
-# by ctest when -C Debug|Releaes|etc is given, and INDIR is passed
+# by ctest when -C Debug|Release|etc is given, and INDIR is passed
 # in from the main cmake run and is the variable that is used
 # by the build system to specify the build directory
 if(NOT "${INTDIR}" STREQUAL ".")

--- a/test/lapack-3.9.1/runtest.cmake
+++ b/test/lapack-3.9.1/runtest.cmake
@@ -1,5 +1,5 @@
 # Replace INTDIR with the value of $ENV{CMAKE_CONFIG_TYPE} that is set
-# by ctest when -C Debug|Releaes|etc is given, and INDIR is passed
+# by ctest when -C Debug|Release|etc is given, and INDIR is passed
 # in from the main cmake run and is the variable that is used
 # by the build system to specify the build directory
 if(NOT "${INTDIR}" STREQUAL ".")


### PR DESCRIPTION
I enabled the tests in the Debian packaging, and it was failing on some of the tests. I thought we need to confirm in what conditions that's happening.

This adds CI for various combinations of 64-bit and not, and then escalating amounts of `SYS_*_LIBRARY`. The failure is 64-bit only, and with system CBLAS supplied, of 12 tests starting with `CBLAS-xscblat1`.

I will investigate and hopefully add a fix to this PR, but I believe this PR is already valuable because it reveals the state of the code "as-is". There are also a couple of trivial updates I thought I'd include here too.